### PR TITLE
Custom model support

### DIFF
--- a/wyoming_microwakeword/__main__.py
+++ b/wyoming_microwakeword/__main__.py
@@ -178,7 +178,6 @@ class MicroWakeWordEventHandler(AsyncEventHandler):
                     if name in self.custom_models.keys():
                         pass
                     else:
-                        _LOGGER.debug("Couldn't find model %s in custom model keys %s", name, self.custom_models.keys())
                         _LOGGER.warning("Unknown model name: %s", name)
         elif AudioStart.is_type(event.type):
             self.detectors = []


### PR DESCRIPTION
This adds a `--custom-model-dir` parameter, similarly to the wyoming-openwakeword project, to allow custom models (and their corresponding json files) to be loaded.